### PR TITLE
Remove multiple underscores in filename

### DIFF
--- a/src/utils/makeFilename.ts
+++ b/src/utils/makeFilename.ts
@@ -28,7 +28,9 @@ export default function makeFilename(
     // max characters
     .substring(0, maxLength)
     // remove trailing underscores
-    .replace(/_+$/, "");
+    .replace(/_+$/, "")
+    // remove multiple underscores
+    .replace(/_{2,}/g, "_");
 
   return filename
 }


### PR DESCRIPTION
Titles like "Namada (NAM): Analyzing the Namada Ecosystem and the Future of Interchain Privacy"

got us this name:

![image](https://github.com/guillermodlpa/upload-notion-images-to-cloudinary/assets/3694800/3d8acc05-b9cb-429d-9377-67c219111361)
